### PR TITLE
Add Jest test for root endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 This is an e-commerce project that I started some time ago, well...it was supposed to be finished but I haven't had time lately. If you want to download the project to use as a base, feel free to do so 🫡.
+\n## Running tests\nRun `npm install` to install dependencies, then `npm test`.

--- a/index.js
+++ b/index.js
@@ -9,16 +9,11 @@ app.get("/", (req, res) => {
     res.sendFile(path.join(__dirname, "index.html"));
 });
 
-const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-    console.log(`Servidor rodando em http://localhost:${PORT}`);
-});
-
-document.addEventListener("DOMContentLoaded", function () {
-    const menuIcon = document.querySelector(".icons");
-    const navbar = document.querySelector(".navbar");
-
-    menuIcon.addEventListener("click", function () {
-        navbar.classList.toggle("active");
+if (require.main === module) {
+    const PORT = process.env.PORT || 3000;
+    app.listen(PORT, () => {
+        console.log(`Servidor rodando em http://localhost:${PORT}`);
     });
-});
+}
+
+module.exports = app;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -24,7 +24,9 @@
     "express": "^4.21.2"
   },
   "devDependencies": {
-    "nodemon": "^3.1.9"
+    "nodemon": "^3.1.9",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
   }
 }
 

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('../index');
+
+describe('GET /', () => {
+  it('should return 200', async () => {
+    await request(app)
+      .get('/')
+      .expect(200);
+  });
+});


### PR DESCRIPTION
## Summary
- export Express app from `index.js`
- add `jest` and `supertest` dev dependencies
- add a basic test to check `GET /` returns 200
- include README note about running tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f64b3ccc08331ab4d17c8aa9cd8e0